### PR TITLE
Bring back vendored build for docs.rs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "themis"]
+	path = libthemis-src/themis
+	url = https://github.com/ilammy/themis.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,14 +5,6 @@ dist: trusty
 rust: stable
 cache: cargo
 
-addons:
-  apt:
-    sources:
-    - sourceline: "deb https://pkgs.cossacklabs.com/stable/ubuntu trusty main"
-      key_url: "https://pkgs.cossacklabs.com/gpg"
-    packages:
-    - libthemis-dev
-
 branches:
   except:
   - /^wip\/.*$/
@@ -20,18 +12,35 @@ branches:
 env:
   global:
   - RUSTFLAGS="-D warnings"
-  - PKG_CONFIG_PATH=$TRAVIS_BUILD_DIR/pkgconfig/system
 
 install:
 - rustup component add clippy-preview
 - rustup component add rustfmt-preview
 - cargo deadlinks --version || cargo install cargo-deadlinks
 
-script:
-- cargo fmt -- --check
-- cargo clean --doc && cargo doc --no-deps && cargo deadlinks
-- cargo clippy --all-targets
-- cargo build
-- cargo test
-- LIBTHEMIS_STATIC=1 cargo build
-- LIBTHEMIS_STATIC=1 cargo test
+jobs:
+  include:
+  - name: System Themis
+    addons:
+      apt:
+        sources:
+          - sourceline: "deb https://pkgs.cossacklabs.com/stable/ubuntu trusty main"
+            key_url: "https://pkgs.cossacklabs.com/gpg"
+        packages:
+          - libthemis-dev
+    env:
+    - PKG_CONFIG_PATH=$TRAVIS_BUILD_DIR/pkgconfig/system
+    script:
+    - cargo fmt -- --check
+    - cargo clean --doc && cargo doc --no-deps && cargo deadlinks
+    - cargo clippy --all-targets
+    - cargo build
+    - cargo test
+    - LIBTHEMIS_STATIC=1 cargo build
+    - LIBTHEMIS_STATIC=1 cargo test
+  - name: Vendored Themis
+    script:
+    - cargo clean --doc && cargo doc --features "vendored" && cargo deadlinks
+    - cargo clippy --all-targets --features "vendored"
+    - cargo build --features "vendored"
+    - cargo test --features "vendored"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 
 The version currently under development.
 
+## New features
+
+- Crate feature `vendored` allows to build and use a vendored copy of the core
+  Themis library in case it is not installed in the system. ([#9])
+  
+[#9]: https://github.com/ilammy/rust-themis/pull/9
+
 Version 0.0.2 — 2018-11-18
 ==========================
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,13 @@ categories = ["cryptography", "api-bindings"]
 license = "Apache-2.0"
 
 [workspace]
-members = ["libthemis-sys"]
+members = ["libthemis-src", "libthemis-sys"]
 
 [badges]
 travis-ci = { repository = "ilammy/rust-themis" }
+
+[features]
+vendored = ["libthemis-sys/vendored"]
 
 [dependencies]
 libthemis-sys = { path = "libthemis-sys", version = "=0.0.2" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["rust-themis developers"]
 description = "High-level cryptographic services for storage and messaging"
 homepage = "https://www.cossacklabs.com/themis/"
 repository = "https://github.com/ilammy/rust-themis"
-documentation = "https://rust-themis.ilammy.net/0.0.2/themis/index.html"
 readme = "README.md"
 keywords = ["crypto", "Themis"]
 categories = ["cryptography", "api-bindings"]
@@ -28,3 +27,7 @@ byteorder = "1.2.7"
 clap = "2.32"
 log = "0.4.5"
 env_logger = "0.5.13"
+
+[package.metadata.docs.rs]
+features = "vendored"
+dependencies = ["libssl-dev"]

--- a/libthemis-src/Cargo.toml
+++ b/libthemis-src/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "libthemis-src"
+version = "0.0.2"
+authors = ["rust-themis developers"]
+description = "Building native Themis library"
+homepage = "https://www.cossacklabs.com/themis/"
+repository = "https://github.com/ilammy/rust-themis"
+readme = "README.md"
+keywords = ["crypto", "Themis"]
+categories = ["development-tools::build-utils"]
+license = "Apache-2.0"
+
+[badges]
+travis-ci = { repository = "ilammy/rust-themis" }
+
+[dependencies]
+copy_dir = "0.1.2"
+make-cmd = "0.1.0"
+
+[dev-dependencies]
+tempfile = "3.0.4"

--- a/libthemis-src/LICENSE
+++ b/libthemis-src/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2018 (c) rust-themis developers
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/libthemis-src/README.md
+++ b/libthemis-src/README.md
@@ -1,0 +1,11 @@
+# libthemis-src
+
+This crate embeds Themis source code
+and implements logic for building it.
+Its main consumer is `libthemis-sys` crate
+which may use it if Themis is not already available on the system. 
+You are not expected to use this crate directly.
+
+## Licensing
+
+The code is distributed under [Apache 2.0 license](LICENSE).

--- a/libthemis-src/src/lib.rs
+++ b/libthemis-src/src/lib.rs
@@ -1,0 +1,261 @@
+// Copyright 2018 (c) rust-themis developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Building native Themis library.
+//!
+//! This crate can be used in `[build-dependencies]` for building Themis library in **build.rs**
+//! for future inclusion into your Rust binaries as a static library.
+//!
+//! # Dependencies
+//!
+//! We expect all native Themis dependencies to be installed and correctly configured:
+//!
+//!   - C compiler
+//!   - GNU Make
+//!   - OpenSSL, LibreSSL, or BoringSSL
+//!
+//! Please refer to [the official documentation][docs] on installing and configuring dependencies.
+//!
+//! [docs]: https://github.com/cossacklabs/themis/wiki/Building-and-installing
+//!
+//! # Examples
+//!
+//! Typical usage from a `*-sys` crate looks like this:
+//!
+//! ```no_run
+//! fn main() {
+//!     #[cfg(feature = "vendored")]
+//!     libthemis_src::make();
+//!
+//!     // Go on with your usual build.rs business, pkg_config crate
+//!     // should be able to locate the local installation of Themis.
+//!     // You'll probably need to use the static library.
+//! }
+//! ```
+
+extern crate copy_dir;
+extern crate make_cmd;
+#[cfg(test)]
+extern crate tempfile;
+
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+/// A builder (literally!) for Themis, produces [`Library`].
+///
+/// [`Library`]: struct.Library.html
+#[derive(Default)]
+pub struct Build {
+    out_dir: Option<PathBuf>,
+}
+
+/// Installed Themis library resulting from a [`Build`].
+///
+/// [`Build`]: struct.Build.html
+pub struct Library {
+    prefix: PathBuf,
+}
+
+/// Build and install Themis into the default location then tell **pkg-config** about it.
+pub fn make() {
+    Build::new().build().set_pkg_config_path();
+}
+
+/// Verifies binary dependencies of Themis build. Panics if dependencies are not satisfied.
+fn check_dependencies() {
+    fn fails_to_run(terms: &[&str]) -> bool {
+        Command::new(&terms[0])
+            .args(&terms[1..])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .is_err()
+    }
+
+    if fails_to_run(&["make", "--version"]) {
+        panic!(
+            "
+
+It seems your system does not have GNU make installed. Make is required
+to build Themis from source.
+
+Please install \"make\" or \"build-essential\" package and try again.
+
+        "
+        );
+    }
+
+    if fails_to_run(&["cc", "--version"]) {
+        panic!(
+            "
+
+It seems your system does not have a C compiler installed. C compiler
+is required to build Themis from source.
+
+Please install \"clang\" (or \"gcc\" and \"g++\") package and try again.
+
+        "
+        );
+    }
+
+    // TODO: check for SomethingSSL, it would be nice for the user
+}
+
+impl Build {
+    /// Prepares a new build.
+    pub fn new() -> Build {
+        Build {
+            out_dir: env::var_os("OUT_DIR").map(|s| PathBuf::from(s).join("themis")),
+        }
+    }
+
+    /// Overrides output directory. Use it if OUT_DIR environment variable is not set or you want
+    /// to customize the output location.
+    pub fn out_dir<P: AsRef<Path>>(&mut self, path: P) -> &mut Self {
+        self.out_dir = Some(path.as_ref().to_path_buf());
+        self
+    }
+
+    /// Builds Themis, panics on any errors.
+    pub fn build(&self) -> Library {
+        check_dependencies();
+
+        let out_dir = self.out_dir.as_ref().expect("OUT_DIR not set");
+        let themis_src_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("themis");
+        let themis_build_dir = out_dir.join("build");
+        let themis_install_dir = out_dir.join("install");
+
+        // Themis uses in-source build. Cargo requires build scripts to never write anything
+        // outside of OUT_DIR so we just have to copy the source code there.
+
+        if !out_dir.exists() {
+            fs::create_dir(&out_dir).expect("mkdir themis");
+        }
+        if themis_build_dir.exists() {
+            fs::remove_dir_all(&themis_build_dir).expect("rm -r themis/build");
+        }
+        if themis_install_dir.exists() {
+            fs::remove_dir_all(&themis_install_dir).expect("rm -r themis/install");
+        }
+
+        copy_dir::copy_dir(&themis_src_dir, &themis_build_dir).expect("cp -r src build");
+        fs::create_dir(&themis_install_dir).expect("mkdir themis/install");
+
+        // Now we can build Themis and install it properly into OUT_DIR.
+        let mut themis_build_and_install = make_cmd::make();
+        themis_build_and_install
+            .current_dir(&themis_build_dir)
+            .env("PREFIX", &themis_install_dir)
+            .arg("install");
+
+        // Cargo sets DEBUG environment variable to zero in release builds, but Themis build simply
+        // checks existence of this variable. We need to unset it to get real release builds,
+        if cfg!(debug) {
+            themis_build_and_install.env("DEBUG", "1");
+        } else {
+            themis_build_and_install.env_remove("DEBUG");
+        }
+
+        let status = themis_build_and_install
+            .status()
+            .expect("failed to run Themis build");
+
+        if !status.success() {
+            panic!("Themis build failed: {}", status);
+        }
+
+        Library {
+            prefix: themis_install_dir,
+        }
+    }
+}
+
+impl Library {
+    /// Installation prefix of the Themis library.
+    pub fn prefix(&self) -> &Path {
+        &self.prefix
+    }
+
+    /// Adds installed Themis library location to PKG_CONFIG_PATH environment variable.
+    pub fn set_pkg_config_path(&self) {
+        let mut paths = env::var_os("PKG_CONFIG_PATH").unwrap_or_default();
+        if !paths.is_empty() {
+            paths.push(":");
+        }
+        paths.push(self.prefix.join("lib/pkgconfig"));
+
+        env::set_var("PKG_CONFIG_PATH", paths);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::env;
+    use std::ffi::OsStr;
+
+    #[test]
+    fn build_and_install() {
+        let temp_dir = tempfile::tempdir().expect("temporary directory");
+        let library = Build::new().out_dir(&temp_dir).build();
+
+        assert!(library.prefix().join("include/themis/themis.h").exists());
+        assert!(library.prefix().join("lib/pkgconfig/libthemis.pc").exists());
+        assert!(library.prefix().join("lib").read_dir().unwrap().count() > 0);
+    }
+
+    #[test]
+    #[allow(non_snake_case)]
+    fn build_and_install_to_OUT_DIR() {
+        let temp_dir = tempfile::tempdir().expect("temporary directory");
+        let library = with_env_var("OUT_DIR", temp_dir.path(), || Build::new().build());
+
+        assert!(library.prefix().join("include/themis/themis.h").exists());
+        assert!(library.prefix().join("lib/pkgconfig/libthemis.pc").exists());
+        assert!(library.prefix().join("lib").read_dir().unwrap().count() > 0);
+    }
+
+    #[test]
+    fn pkg_config_setting() {
+        let temp_dir = tempfile::tempdir().expect("temporary directory");
+        let library = Build::new().out_dir(&temp_dir).build();
+
+        with_env_var("PKG_CONFIG_PATH", "", || {
+            library.set_pkg_config_path();
+
+            let pkg_path = env::var("PKG_CONFIG_PATH").expect("PKG_CONFIG_PATH");
+            let prefix = library.prefix().to_str().expect("prefix").to_owned();
+            assert!(pkg_path.contains(&prefix));
+        });
+    }
+
+    fn with_env_var<K, V, F, T>(key: K, value: V, f: F) -> T
+    where
+        K: AsRef<OsStr>,
+        V: AsRef<OsStr>,
+        F: FnOnce() -> T,
+    {
+        let old_value = env::var_os(&key);
+        env::set_var(&key, value);
+        let result = f();
+        match old_value {
+            Some(old_value) => env::set_var(&key, old_value),
+            None => env::remove_var(&key),
+        }
+        result
+    }
+}

--- a/libthemis-sys/Cargo.toml
+++ b/libthemis-sys/Cargo.toml
@@ -22,3 +22,7 @@ bindgen = "0.42.0"
 cc = "1.0"
 libthemis-src = { path = "../libthemis-src", version = "=0.0.2", optional = true }
 pkg-config = "0.3.14"
+
+[package.metadata.docs.rs]
+features = "vendored"
+dependencies = ["libssl-dev"]

--- a/libthemis-sys/Cargo.toml
+++ b/libthemis-sys/Cargo.toml
@@ -14,7 +14,11 @@ links = "themis"
 [badges]
 travis-ci = { repository = "ilammy/rust-themis" }
 
+[features]
+vendored = ["libthemis-src"]
+
 [build-dependencies]
 bindgen = "0.42.0"
 cc = "1.0"
+libthemis-src = { path = "../libthemis-src", version = "=0.0.2", optional = true }
 pkg-config = "0.3.14"

--- a/libthemis-sys/build.rs
+++ b/libthemis-sys/build.rs
@@ -14,6 +14,8 @@
 
 extern crate bindgen;
 extern crate cc;
+#[cfg(feature = "vendored")]
+extern crate libthemis_src;
 extern crate pkg_config;
 
 use std::env;
@@ -50,11 +52,17 @@ fn main() {
 
 /// Embarks on an incredible adventure and returns with a suitable Themis (or dies trying).
 fn get_themis() -> Library {
-    let result = pkg_config::Config::new()
-        .env_metadata(true)
-        .arg("libsoter") // TODO: remove this together with themis_shims
-        .probe("libthemis");
-    match result {
+    #[cfg(feature = "vendored")]
+    libthemis_src::make();
+
+    let mut pkg_config = pkg_config::Config::new();
+    pkg_config.env_metadata(true);
+    pkg_config.arg("libsoter"); // TODO: remove this together with themis_shims
+
+    #[cfg(feature = "vendored")]
+    pkg_config.statik(true);
+
+    match pkg_config.probe("libthemis") {
         Ok(library) => return library,
         Err(error) => panic!(format!(
             "


### PR DESCRIPTION
It turns out that vendored builds may be useful for docs.rs so we bring it back.

Unfortunately, Themis is not available in standard Linux repositories and is not preinstalled on most of the systems. Thus docs.rs is unable to build documentation for Themis because `cargo doc` requires compilation of dependent crates.

I have tried 'solving' this issue by building documentation manually (see **gh-pages** branch in this repo, specifically commit 75dccfe). However, this won't scale and I don't really like how this way ties the docs to my domain. Ideally the API documentation should be hosted by either upstream (Cossack Labs) or by docs.rs.

Vendored build will allow building Themis on docs.rs and thus should enable documenting the root `themis` crate. Therefore we revert commit 497ffcc and improve it.

As before, the source code is split into a dedicated crate `libthemis-src` (mimicking the `openssl` crate). It is used by `libthemis-sys` if the "vendored" feature is enabled. Note that currently the vendored build does not replace the system library. We will still prefer the system library if it is available. Also note that we always link statically against the vendored library.

We are not going to locate the library manually. We stick with using pkg-config for that. Themis version pinned via submodule is the latest master which does install *.pc files correctly. (Currently I use my own fork which fixes another issue with ldconfig. Later the submodule should be updated to the upstream master.)

Travis build script has been updated to check the vendored build without core Themis library installed.

Note that I do not expect the "vendored" feature to be used for anything other than docs.rs. Yes, this is a hack. Yes, it may even work. However, transitive dependencies are hard to enfore with vendored builds so I'm not seriously considering this as a supported option.

docs.rs supports metadata which influences how the crate docs are built. Tell docs.rs to use a "vendored" build which requires OpenSSL libraries to be installed. Everything else like Clang and GNU Make should be already there.

With this we won't need to host our documentation ourselves so drop the "documentation" line from Cargo.toml and revert to using docs.rs.