### PR TITLE
Securely zero key material before freeing memory

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ vendored = ["libthemis-sys/vendored"]
 
 [dependencies]
 libthemis-sys = { path = "libthemis-sys", version = "=0.0.2-2" }
+zeroize = "0.5.2"
 
 [dev-dependencies]
 byteorder = "1.2.7"

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -129,6 +129,8 @@
 
 use std::fmt;
 
+use zeroize::Zeroize;
+
 use crate::{
     bindings::{themis_get_key_kind, themis_is_valid_key},
     error::{Error, ErrorKind, Result},
@@ -138,8 +140,6 @@ use crate::{
 /// Key material.
 #[derive(Clone, Eq, PartialEq, Hash)]
 pub(crate) struct KeyBytes(Vec<u8>);
-
-// TODO: securely zero memory when dropping KeyBytes (?)
 
 impl KeyBytes {
     /// Makes a key from an owned byte vector.
@@ -166,6 +166,13 @@ impl KeyBytes {
 impl fmt::Debug for KeyBytes {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "KeyBytes({} bytes)", self.0.len())
+    }
+}
+
+// Make sure that sensitive key material is removed from memory as soon as it is no longer needed.
+impl Drop for KeyBytes {
+    fn drop(&mut self) {
+        self.0.zeroize();
     }
 }
 

--- a/tests/keys.rs
+++ b/tests/keys.rs
@@ -86,3 +86,27 @@ fn join_mismatching_keys() {
     let error = KeyPair::try_join(secret_ec, public_rsa).expect_err("kind mismatch");
     assert_eq!(error.kind(), ErrorKind::InvalidParameter);
 }
+
+#[test]
+fn zero_memory_on_drop() {
+    let (secret, public) = gen_ec_key_pair().split();
+
+    let secret_bytes = slice_alias(secret.as_ref());
+    let public_bytes = slice_alias(public.as_ref());
+
+    assert!(!secret_bytes.iter().all(|&byte| byte == 0));
+    assert!(!public_bytes.iter().all(|&byte| byte == 0));
+
+    drop(secret);
+    drop(public);
+
+    // Technically, the following is *not* safe and is undefined behavior (the slices contain
+    // dangling pointers that cannot be dereferenced now), but it's gonna be alright, darling.
+
+    assert!(secret_bytes.iter().all(|&byte| byte == 0));
+    assert!(public_bytes.iter().all(|&byte| byte == 0));
+}
+
+fn slice_alias<'a, 'b, T>(slice: &'a [T]) -> &'b [T] {
+    unsafe { std::slice::from_raw_parts(slice.as_ptr(), slice.len()) }
+}


### PR DESCRIPTION
It is a good security practice to wipe sensitive data from memory as soon as it no longer needed. Obviously, the data has to be in memory for some time but we should not keep it around for more than absolutely necessary. The data in a memory region is not erased when the memory is freed so we have to make sure it's gone ourselves.

Initially I was overconfident and tried writing my own zeroing. Don't do this, kids. There's a whole load of issues that need to be resolved in order to *securely* zero out a memory region. You can read the implementation details in the source code of ["zeroize"](https://github.com/iqlusioninc/crates/blob/3dfc481c173a142c213a3a25fd864b7d3ca223fb/zeroize/src/lib.rs#L53) or elsewhere.

Therefore we use a dedicated library for the task. It makes sure that the compiler does not optimize away the code that tries its best to write zeros into the main memory (not the caches). Currently zeroize does not use these fancy functions like `memset_s()`, `explicit_bzero()`, `RtlSecureZeroMemory()`, etc. but it might it the future.

There's also a test to verify that the memory is indeed zeroed out. By definition, the test contains some technically unsafe code, but it's unlikely to crash or misbehave.

@Lagovas was concerned about this feature in cossacklabs/themis#340. These changes will be included in the next bulk PR into the main Themis repository (along with other stuff).